### PR TITLE
feat: add comprehensive GitHub CI test coverage reports (CMD-27)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
 
   build-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
@@ -81,7 +83,7 @@ jobs:
         if: matrix.python-version == '3.12'
         with:
           file: ./coverage.xml
-          flags: unittests
+          flags: unittests,py312
           name: codecov-umbrella
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Tests
         run: |
-          poetry run pytest --cov=src --cov=scripts \
+          poetry run pytest --cov=src --cov=scripts --cov-branch \
             --cov-report=term-missing \
             --cov-report=xml \
             --cov-report=html \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,9 +60,31 @@ jobs:
 
       - name: Tests
         run: |
-          poetry run pytest --cov=scripts \
+          poetry run pytest --cov=src --cov=scripts \
             --cov-report=term-missing \
+            --cov-report=xml \
+            --cov-report=html \
             --cov-fail-under=80
+
+      - name: Upload coverage reports to GitHub
+        uses: actions/upload-artifact@v4
+        if: matrix.python-version == '3.12'
+        with:
+          name: coverage-reports-${{ matrix.python-version }}
+          path: |
+            coverage.xml
+            htmlcov/
+          retention-days: 30
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        if: matrix.python-version == '3.12'
+        with:
+          file: ./coverage.xml
+          flags: unittests
+          name: codecov-umbrella
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: CLI Smoke Test
         run: poetry run conmd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Upload coverage reports to GitHub
         uses: actions/upload-artifact@v4
-        if: matrix.python-version == '3.12'
+        if: always() && matrix.python-version == '3.12'
         with:
           name: coverage-reports-${{ matrix.python-version }}
           path: |

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # confluence-markdown
 
+[![CI](https://github.com/frankbhome/confluence-markdown/actions/workflows/ci.yml/badge.svg)](https://github.com/frankbhome/confluence-markdown/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/frankbhome/confluence-markdown/branch/main/graph/badge.svg)](https://codecov.io/gh/frankbhome/confluence-markdown)
+
 A Python-based tool to synchronize documents between Markdown (in Git) and
 Confluence pages. The project aims to support two‑way conversion and CI/CD
 automation.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # confluence-markdown
 
-[![CI](https://github.com/frankbhome/confluence-markdown/actions/workflows/ci.yml/badge.svg)](https://github.com/frankbhome/confluence-markdown/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/frankbhome/confluence-markdown/branch/main/graph/badge.svg)](https://codecov.io/gh/frankbhome/confluence-markdown)
+[![CI (main)](https://github.com/frankbhome/confluence-markdown/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/frankbhome/confluence-markdown/actions/workflows/ci.yml?query=branch%3Amain)
+[![codecov (main)](https://codecov.io/gh/frankbhome/confluence-markdown/branch/main/graph/badge.svg)](https://codecov.io/gh/frankbhome/confluence-markdown)
 
 A Python-based tool to synchronize documents between Markdown (in Git) and
 Confluence pages. The project aims to support two‑way conversion and CI/CD


### PR DESCRIPTION
- Enhanced CI workflow to collect coverage for both src and scripts directories
- Added XML and HTML coverage report generation for GitHub Actions artifacts
- Integrated Codecov for detailed coverage tracking and PR comments
- Added CI and coverage badges to README for visual status indicators
- Upload coverage artifacts with 30-day retention
- Maintain 80% coverage threshold requirement
- Support coverage reporting across Python 3.9-3.12 matrix

Coverage reports now available as GitHub Actions artifacts and Codecov dashboard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Added CI and Codecov badges to the README for quick visibility into build and test and coverage status.

- Chores
  - Enhanced CI to collect coverage (including branch coverage) for source and scripts, output terminal/XML/HTML reports, and retain uploaded coverage artifacts for 30 days.
  - Publishes coverage to Codecov during Python 3.12 runs (non-blocking on upload failures) while keeping existing CLI smoke tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->